### PR TITLE
Syntax bug fixes in noteService

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,1 +1,0 @@
-Test PR/commit

--- a/src/services/noteService.ts
+++ b/src/services/noteService.ts
@@ -118,3 +118,4 @@ export const noteService = {
       throw error;
     }
   },
+};


### PR DESCRIPTION
This commit removed the test message from CHANGES.md and fixed the missing '}' and 'extra' , from noteService.ts