### PR TITLE
Colour fixes + attempted fix of dark mode toggle render

### DIFF
--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -108,15 +108,15 @@ export default function NotePage({ params }: { params: { id: string } }) {
     <div className="max-w-2xl mx-auto">
       {isEditing ? (
         <>
-          <h1 className="text-2xl font-bold mb-6">Edit Note</h1>
-          <div className="bg-white shadow rounded-lg p-6">
+          <h1 className="text-2xl font-bold mb-6 dark:text-white">Edit Note</h1>
+          <div className="bg-white shadow rounded-lg p-6 dark:bg-gray-800">
             <NoteForm note={note} onSubmit={handleUpdate} isEdit={true} />
           </div>
         </>
       ) : (
         <>
           <div className="flex justify-between items-center mb-6">
-            <h1 className="text-2xl font-bold">{note.title}</h1>
+            <h1 className="text-2xl font-bold dark:text-white">{note.title}</h1>
             <div className="space-x-2">
               <button
                 onClick={() => setIsEditing(true)}
@@ -133,8 +133,8 @@ export default function NotePage({ params }: { params: { id: string } }) {
             </div>
           </div>
 
-          <div className="bg-white shadow rounded-lg p-6">
-            <div className="text-sm text-gray-500 mb-4">
+          <div className="bg-white shadow rounded-lg p-6 dark:text-white dark:bg-gray-600">
+              <div className="text-sm text-gray-500 mb-4 dark:text-white">
               <p>Created: {formatDate(note.createdAt)}</p>
               <p>Last updated: {formatDate(note.updatedAt)}</p>
             </div>

--- a/src/app/notes/new/page.tsx
+++ b/src/app/notes/new/page.tsx
@@ -28,7 +28,7 @@ export default function NewNotePage() {
         </div>
       )}
 
-      <div className="bg-white shadow rounded-lg p-6">
+      <div className="bg-white shadow rounded-lg p-6 dark:bg-gray-800">
         <NoteForm onSubmit={handleSubmit} />
       </div>
     </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -12,7 +12,6 @@ export default function Navigation() {
   const [isDarkMode, setIsDarkMode] = useState(false);
 
   const toggleDarkMode = () => {
-    console.log('reached')
     setIsDarkMode(!isDarkMode);
   };
 

--- a/src/components/NoteForm.tsx
+++ b/src/components/NoteForm.tsx
@@ -83,7 +83,7 @@ export default function NoteForm({
       <div>
         <label
           htmlFor="title"
-          className="block text-sm font-medium text-gray-700 mb-1"
+          className="block text-sm font-medium text-gray-700 mb-1 dark:text-white"
         >
           Title
         </label>
@@ -92,7 +92,7 @@ export default function NoteForm({
           type="text"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600"
+          className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white"
           placeholder="Note title"
         />
       </div>
@@ -100,7 +100,7 @@ export default function NoteForm({
       <div>
         <label
           htmlFor="content"
-          className="block text-sm font-medium text-gray-700 mb-1"
+          className="block text-sm font-medium text-gray-700 mb-1 dark:text-white"
         >
           Content
         </label>
@@ -109,7 +109,7 @@ export default function NoteForm({
           value={content}
           onChange={(e) => setContent(e.target.value)}
           rows={8}
-          className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600"
+          className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white"
           placeholder="Note content"
         ></textarea>
       </div>
@@ -118,7 +118,7 @@ export default function NoteForm({
         <button
           type="button"
           onClick={() => router.back()}
-          className="px-4 py-2 border rounded text-gray-700 hover:bg-gray-100"
+          className="px-4 py-2 border rounded text-gray-700 hover:bg-gray-100 dark:text-white"
         >
           Cancel
         </button>

--- a/src/components/NoteItem.tsx
+++ b/src/components/NoteItem.tsx
@@ -43,13 +43,13 @@ export default function NoteItem({ note, onDelete }: NoteItemProps) {
   };
 
   return (
-    <div className="bg-white rounded shadow p-4 h-full flex flex-col">
+    <div className="bg-white rounded shadow p-4 h-full flex flex-col dark:bg-gray-800">
       <div className="flex-grow">
-        <h3 className="text-lg font-semibold mb-2">{note.title}</h3>
-        <p className="text-gray-600 mb-4 text-sm">
+        <h3 className="text-lg font-semibold mb-2 dark:text-white">{note.title}</h3>
+        <p className="text-gray-600 mb-4 text-sm dark:text-white">
           {formatDate(note.updatedAt)}
         </p>
-        <p className="text-gray-800 mb-4">{truncateContent(note.content)}</p>
+        <p className="text-gray-800 mb-4 dark:text-white">{truncateContent(note.content)}</p>
       </div>
 
       <div className="flex justify-between mt-4 pt-4 border-t border-gray-100">


### PR DESCRIPTION
The dark mode toggle doesn't work until another feature of the website is first used, e.g. 'view all notes' is clicked or something else that causes the state to change, only then does the button become responsive. Unable to come up with a solution so far.